### PR TITLE
Returning promises to stop warnings

### DIFF
--- a/src/routes/task.js
+++ b/src/routes/task.js
@@ -9,9 +9,9 @@ router.get('/', (request, response, next) => {
 
   user.findByHandle(currentUser.handle)
   .then( returnedUser => {
-    task.getBy('user_id', returnedUser.id)
+    return task.getBy('user_id', returnedUser.id)
     .then( tasks => {
-      response.json(tasks)
+      return response.json(tasks)
     } )
     .catch( err => {
       console.log(`Error retrieving tasks for user ${currentUser.handle} from the db`, err);


### PR DESCRIPTION
Fixes  Some warnings that happen whenever you load a page.

## Overview

We forgot to return a promise in our Task routes.  It is now returned.

## Data Model / DB Schema Changes

N/A

## Environment / Configuration Changes

N/A

## Notes

N/A
