### PR TITLE
Reorganized props and layout of Task component

### DIFF
--- a/src/browser/components/molecules/Task/index.css
+++ b/src/browser/components/molecules/Task/index.css
@@ -9,6 +9,8 @@
   margin: 5px;
   font-family: comic;
   border-radius: 3px;
+  display: flex;
+  justify-content: space-between;
 }
 
 
@@ -43,9 +45,34 @@
   border: papayawhip 1px solid;
   padding: 2px 6px;
   margin: 3px;
+  width: 580px;
+  min-height: 60px;
+}
+
+.NotifyCircle{
+  border-radius: 50%;
+  width: 25px;
+  height: 25px;
+  background-color: rgba(0,0,0,0.3);
+  border: papayawhip 1px solid;
+  margin: 4px;
+}
+
+.DueDateDiv{
+  border-left: papayawhip 2px solid;
+  padding-left: 8px;
+  width: 175px;
+}
+
+.NotifyWrapper {
+  display: flex;
 }
 
 .AlertDueDate {
   color: yellow;
   font-weight: bold;
+}
+
+.CompleteButton{
+  margin-top: 4px
 }

--- a/src/browser/components/molecules/Task/index.js
+++ b/src/browser/components/molecules/Task/index.js
@@ -23,7 +23,7 @@ export default class Task extends Component {
       credentials: 'same-origin',
       body: JSON.stringify({is_complete: true})
     }
-    fetch( `/api/task/${this.props.id}`, options )
+    fetch( `/api/task/${this.props.task.id}`, options )
     .then( taskPromise => {
       return taskPromise.json()
     })
@@ -39,6 +39,7 @@ export default class Task extends Component {
   taskStyles(task){
     let ourStyles = {
       mainStyle: styles.TaskDiv,
+      notifyText: ''
     }
     if( task.is_complete ){
       ourStyles.mainStyle = styles.TaskComplete
@@ -48,12 +49,15 @@ export default class Task extends Component {
     let diffInDays = moment(task.due_date).diff(moment(), 'days')
     if (diffInDays < 0) {
       ourStyles.mainStyle = styles.PastDue
+      ourStyles.notifyText = 'Past Due!'
       return ourStyles
     } else if( diffInDays <= 1) {
       ourStyles.mainStyle = styles.SoonDue
+      ourStyles.notifyText = 'Due Immediately!'
       return ourStyles
     } else if( diffInDays <= 3) {
       ourStyles.mainStyle = styles.NearDue
+      ourStyles.notifyText = 'Due Soon'
       return ourStyles}
       else {
         return ourStyles
@@ -61,33 +65,69 @@ export default class Task extends Component {
   }
 
   render () {
-    let dateString = utils.toStandardDate(this.props.due_date)
+    let task = this.props.task
 
-    let completeDate = this.props.is_complete
-      ? `Complete at: ${utils.toStandardDate(this.props.completed_on)}`
+    let dateString = utils.toStandardDate(task.due_date)
+
+    let completeDate = task.is_complete
+      ? `Complete at: ${utils.toStandardDate(task.completed_on)}`
       : null
 
-    let completeButton = !this.props.is_complete
-      ? <button className={styles.CompleteTask} ref='completeTask' onClick={this.isCompleteHandler.bind(this)}>Task Completed</button>
+    let completeButton = !task.is_complete
+      ? <button className={styles.CompleteButton} ref='completeTask' onClick={this.isCompleteHandler.bind(this)}>Mark Complete</button>
       : null
 
-    let dueDateJSX = !this.props.is_complete
-      ? <div> Due Date: {dateString} </div>
+    let dueDateJSX = !task.is_complete
+      ? <div> Due : {dateString} </div>
       : null
 
-    let {mainStyle} = this.taskStyles(this.props)
+    let {mainStyle, notifyText} = this.taskStyles(task)
+
+    let notifyTextJSX = notifyText
+    let notifyCircle = <div className={styles.NotifyCircle}></div>
 
     return (
       <div>
         <div className={mainStyle}>
-          <div className={styles.TaskDescription}>
-            {this.props.description}
+          <div> <b>{task.title}</b>
+            <div className={styles.TaskDescription}>
+              {task.description}
+            </div>
           </div>
-          {dueDateJSX}
-          <div>{completeDate}</div>
-          {completeButton}
+          <div className={styles.DueDateDiv}>
+            <div> {dueDateJSX}
+              <div className={styles.NotifyWrapper}>
+                {notifyCircle}
+                <div className={styles.NotifyText}>{notifyTextJSX}</div><div>{completeDate}</div>
+                </div>
+            </div>
+            {completeButton}
+          </div>
         </div>
       </div>
     )
   }
 }
+
+//
+//   return (
+//     <div>
+//       <div className={mainStyle}>
+//         <div className={styles.TaskBody}>
+//           {this.props.task.description}
+//         </div>
+
+//         <div className={styles.dueDateDiv}>
+//           <div> {dueDateJSX}
+//             <div className={styles.NotifyWrapper}>
+//               {notifyCircle}
+//               <div className={styles.NotifyText}>{notifyText}</div><div>{completeDate}</div>
+//             </div>
+//           </div>
+//           {completeButton}
+//         </div>
+//       </div>
+//     </div>
+//   )
+// }
+// }

--- a/src/browser/components/molecules/Task/index.js
+++ b/src/browser/components/molecules/Task/index.js
@@ -108,26 +108,3 @@ export default class Task extends Component {
     )
   }
 }
-
-//
-//   return (
-//     <div>
-//       <div className={mainStyle}>
-//         <div className={styles.TaskBody}>
-//           {this.props.task.description}
-//         </div>
-
-//         <div className={styles.dueDateDiv}>
-//           <div> {dueDateJSX}
-//             <div className={styles.NotifyWrapper}>
-//               {notifyCircle}
-//               <div className={styles.NotifyText}>{notifyText}</div><div>{completeDate}</div>
-//             </div>
-//           </div>
-//           {completeButton}
-//         </div>
-//       </div>
-//     </div>
-//   )
-// }
-// }

--- a/src/browser/components/molecules/TaskList/index.js
+++ b/src/browser/components/molecules/TaskList/index.js
@@ -46,13 +46,8 @@ export default class TaskList extends Component {
     return tasks.map( task =>
       <Task
         key={task.id}
-        id={task.id}
-        title={task.title}
-        description={task.description}
-        fetchTasks={this.fetchTasks.bind(this)}
-        due_date={task.due_date}
-        completed_on={task.updated_at}
-        is_complete={task.is_complete}/>)
+        task={task}
+        fetchTasks={this.fetchTasks.bind(this)}/>)
   }
 
   render() {


### PR DESCRIPTION

## Overview

Changed how props are passed to the Task component and reorganized the html of the component to something a little closer to the desired final layout.

## Data Model / DB Schema Changes

Assumes you have the migration that renames task body to `description` and adds the `title` column.

## Environment / Configuration Changes

N/A

## Notes

N/A
