### PR TITLE
tasks are sorted according to title if the days to complete is the same

### DIFF
--- a/src/database/queries/template_task.js
+++ b/src/database/queries/template_task.js
@@ -13,6 +13,7 @@ const deleteAll = () =>
 const getAll = () =>
   _.findAll( 'template_task' )
   .orderBy('days_to_complete', 'asc')
+  .orderBy('title', 'asc')
 
 const getBy = ( column, data ) =>
   _.findAllWhere( 'template_task', column, data )

--- a/src/utils/admins.js
+++ b/src/utils/admins.js
@@ -1,4 +1,4 @@
-const ADMIN_GITHUB_HANDLES = ['shereefb', 'carlabagdonas', 'needdra', 'punitrathore']
+const ADMIN_GITHUB_HANDLES = ['shereefb', 'carlabagdonas', 'needdra', 'punitrathore', 'yaseenagag']
 
 export default function isAdmin(githubHandle) {
   return ADMIN_GITHUB_HANDLES.includes(githubHandle)


### PR DESCRIPTION
Fixes # .

## Overview

Tasks are now sorted by days to complete first and if they clash they sort by title. 
files changed are template-task.js under queries

## Data Model / DB Schema Changes
N/A

## Environment / Configuration Changes
N/A

## Notes
N/A


